### PR TITLE
fix missing OR (my bad lol), fix #2

### DIFF
--- a/klatu/lib/freeAction.tpa
+++ b/klatu/lib/freeAction.tpa
@@ -103,19 +103,20 @@ BEGIN
 							AND sTypeB = sType
 							AND sBonusB = sBonus
 						) BEGIN									// effect is related
-							READ_STRREF (off + 0x04) strRef
+						 	READ_STRREF (off + 0x04) strRef
                                                         SET c7__c7__remove_this_effect = 0
                                                         PATCH_IF opcode == 206 BEGIN
                                                           READ_ASCII (off + 0x14) c7__c7__resource
                                                           INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                             READ_STRREF 0x8 c7__c7__spell_name
                                                           END
-                                                          PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                          PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                             SET c7__c7__remove_this_effect = 1
                                                           END
                                                         END
                                                         PATCH_IF (
                                                                 c7__c7__remove_this_effect == 1
+								OR
 								opcode = 126					// opcode: move mod -
 								OR 
 								opcode = 176					// opcode: move mod +
@@ -131,6 +132,8 @@ BEGIN
 								(opcode = 240 AND param2 = 38)	// remove icon: haste
 								OR
 								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
+								OR
+								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
 							) BEGIN
 								LPF REMOVE_ABILITY_EFFECT INT_VAR abilLen = abilLen abilIdx = a idx = g END
 								PATCH_IF (g < f) BEGIN
@@ -228,12 +231,13 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
                                                 PATCH_IF (
                                                         c7__c7__remove_this_effect == 1
+							OR
 							opcode = 126					// opcode: move mod -
 							OR 
 							opcode = 176					// opcode: move mod +
@@ -249,6 +253,8 @@ BEGIN
 							(opcode = 240 AND param2 = 38)	// remove icon: haste
 							OR
 							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
+							OR
+							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
 						) BEGIN
 							LPF REMOVE_EFFECT INT_VAR abilLen = abilLen idx = g END
 							PATCH_IF (g < f) BEGIN
@@ -352,12 +358,13 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
                                                 PATCH_IF (
                                                         c7__c7__remove_this_effect == 1
+							OR
 							opcode = 126					// opcode: move mod -
 							OR 
 							opcode = 176					// opcode: move mod +


### PR DESCRIPTION
Fixed some missing ORs, guess I didn't copy an entire line when I submitted the first PR, mb.

Did some impressive research and found out Hast as opposed to Haste covers both languages, however I don't know if some spell that should actually stay blocked might also have "Hast" in its name in german. It's case sensitive either way so I have faith we're on the clear. Also copy pasted the other bit that checks for the "Hasted" string in german around, so both cases are now covered.

Edit: accidentally closed this one, re-opened an identical PR either way so disregard this one, my bad.