### PR TITLE
fix missing ORs in checks (my bad), fix #2

### DIFF
--- a/klatu/lang/english/setup.tra
+++ b/klatu/lang/english/setup.tra
@@ -12,7 +12,7 @@
 STATISTICS: 
 
 Equipped abilities: 
-– Bonus to wild surge rolls on wearer
+â€“ Bonus to wild surge rolls on wearer
 
 Weight: 1~
 @8 = ~Prepared Wishes~
@@ -421,3 +421,6 @@ Additionally, this script offers basic control over the character's general beha
 @220 = ~Has permanent Free Action.~
 @221 = ~Regenerates 1 HP per round.~
 @222 = ~Immune to poisons and diseases.~
+@223 = ~Haste~ // should say "Haste" as per the spell's name
+@224 = ~Improved Haste~ //same deal here
+@225 = ~Hasted~ // should be the string that shows up when you get hasted

--- a/klatu/lang/german/setup.tra
+++ b/klatu/lang/german/setup.tra
@@ -421,4 +421,6 @@ Zusätzlich habt Ihr Kontrolle über das grundlegende Verhalten des Charakters. Ab
 @220 = ~Hat permanente Bewegungsfreiheit.~
 @221 = ~Regeneriert 1 Trefferpunkt pro Runde.~
 @222 = ~Immun gegen Gifte und Krankheiten.~
-
+@223 = ~Hast~
+@224 = ~Verbesserte Hast~
+@225 = ~Beschleunigt~

--- a/klatu/lib/freeAction.tpa
+++ b/klatu/lib/freeAction.tpa
@@ -110,7 +110,11 @@ BEGIN
                                                           INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                             READ_STRREF 0x8 c7__c7__spell_name
                                                           END
-                                                          PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
+                                                          SPRINT c7__haste_name @223
+                                                          SPRINT c7__improved_haste_name @224
+                                                          SPRINT c7__hasted_string @225
+                                                          PATCH_IF ("%c7__c7__spell_name%" STR_EQ "%c7__improved_haste_name%" ||
+                                                                    "%c7__c7__spell_name%" STR_EQ "%c7__haste_name%") BEGIN
                                                             SET c7__c7__remove_this_effect = 1
                                                           END
                                                         END
@@ -131,9 +135,7 @@ BEGIN
 								OR 
 								(opcode = 240 AND param2 = 38)	// remove icon: haste
 								OR
-								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
-								OR
-								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
+								(opcode = 267 AND (~%strRef%~ STR_EQ "%c7__hasted_string%"))      // prevent string: hasted
 							) BEGIN
 								LPF REMOVE_ABILITY_EFFECT INT_VAR abilLen = abilLen abilIdx = a idx = g END
 								PATCH_IF (g < f) BEGIN
@@ -231,7 +233,11 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
+                                                  SPRINT c7__haste_name @223
+                                                  SPRINT c7__improved_haste_name @224
+                                                  SPRINT c7__hasted_string @225
+                                                  PATCH_IF ("%c7__c7__spell_name%" STR_EQ "%c7__improved_haste_name%" ||
+                                                            "%c7__c7__spell_name%" STR_EQ "%c7__haste_name%") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
@@ -252,9 +258,7 @@ BEGIN
 							OR 
 							(opcode = 240 AND param2 = 38)	// remove icon: haste
 							OR
-							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
-							OR
-							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
+							(opcode = 267 AND (~%strRef%~ STR_EQ "%c7__hasted_string%"))      // prevent string: hasted
 						) BEGIN
 							LPF REMOVE_EFFECT INT_VAR abilLen = abilLen idx = g END
 							PATCH_IF (g < f) BEGIN
@@ -358,7 +362,11 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
+                                                  SPRINT c7__haste_name @223
+                                                  SPRINT c7__improved_haste_name @224
+                                                  SPRINT c7__hasted_string @225
+                                                  PATCH_IF ("%c7__c7__spell_name%" STR_EQ "%c7__improved_haste_name%" ||
+                                                            "%c7__c7__spell_name%" STR_EQ "%c7__haste_name%") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
@@ -379,9 +387,7 @@ BEGIN
 							OR 
 							(opcode = 240 AND param2 = 38)	// remove icon: haste
 							OR
-							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Hasted~))	// prevent string: hasted
-							OR
-							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
+							(opcode = 267 AND (~%strRef%~ STR_EQ "%c7__hasted_string%"))      // prevent string: hasted
 						) BEGIN
 							LPF REMOVE_EFFECT_CRE INT_VAR idx = g END
 							PATCH_IF (g < f) BEGIN

--- a/klatu/lib/freeAction.tpa
+++ b/klatu/lib/freeAction.tpa
@@ -110,12 +110,13 @@ BEGIN
                                                           INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                             READ_STRREF 0x8 c7__c7__spell_name
                                                           END
-                                                          PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                          PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                             SET c7__c7__remove_this_effect = 1
                                                           END
                                                         END
                                                         PATCH_IF (
                                                                 c7__c7__remove_this_effect == 1
+								OR
 								opcode = 126					// opcode: move mod -
 								OR 
 								opcode = 176					// opcode: move mod +
@@ -131,6 +132,8 @@ BEGIN
 								(opcode = 240 AND param2 = 38)	// remove icon: haste
 								OR
 								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
+								OR
+								(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
 							) BEGIN
 								LPF REMOVE_ABILITY_EFFECT INT_VAR abilLen = abilLen abilIdx = a idx = g END
 								PATCH_IF (g < f) BEGIN
@@ -228,12 +231,13 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
                                                 PATCH_IF (
                                                         c7__c7__remove_this_effect == 1
+							OR
 							opcode = 126					// opcode: move mod -
 							OR 
 							opcode = 176					// opcode: move mod +
@@ -249,6 +253,8 @@ BEGIN
 							(opcode = 240 AND param2 = 38)	// remove icon: haste
 							OR
 							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~hasted~))	// prevent string: hasted
+							OR
+							(opcode = 267 AND (~%strRef%~ STRING_EQUAL_CASE ~Beschleunigt~))	// prevent string: hasted
 						) BEGIN
 							LPF REMOVE_EFFECT INT_VAR abilLen = abilLen idx = g END
 							PATCH_IF (g < f) BEGIN
@@ -352,12 +358,13 @@ BEGIN
                                                   INNER_PATCH_FILE "%c7__c7__resource%.spl" BEGIN
                                                     READ_STRREF 0x8 c7__c7__spell_name
                                                   END
-                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Haste") BEGIN
+                                                  PATCH_IF NOT ("%c7__c7__spell_name%" STRING_CONTAINS_REGEXP "Hast") BEGIN
                                                     SET c7__c7__remove_this_effect = 1
                                                   END
                                                 END
                                                 PATCH_IF (
                                                         c7__c7__remove_this_effect == 1
+							OR
 							opcode = 126					// opcode: move mod -
 							OR 
 							opcode = 176					// opcode: move mod +


### PR DESCRIPTION
Accidentally closed the previous PR because I didn't notice it was on a second branch on my own repo, so I had to re-submit it, sorry. Either way, here it is.

Fixed some missing ORs, guess I didn't copy an entire line when I submitted the first PR, mb.

Did some impressive research and found out Hast as opposed to Haste covers both languages, however I don't know if some spell that should actually stay blocked might also have "Hast" in its name in german. It's case sensitive either way so I have faith we're on the clear. Also copy pasted the other bit that checks for the "Hasted" string in german around, so both cases are now covered.